### PR TITLE
Support the ::: syntax for divs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,9 +41,9 @@ const microdown = function () {
       '<!--$1-->',
 
       // pre format block
-      /^("""|```)(.*)\n((.*\n)*?)\1/gm,
+      /^("""+|:::+|```+)(.*)\n((.*\n)*?)\1/gm,
       (match, wrapper, c, text) =>
-        wrapper === '"""' ?
+        !/`/.test(wrapper) ?
           tag('div', parse(text, options), {class: c})
           : options && options.preCode 
           ? tag('pre', tag('code', encode(text), {class: c}))


### PR DESCRIPTION
This syntax is from Pandoc: https://pandoc.org/MANUAL.html#divs-and-spans

Also allow for three or more characters, e.g., `""""`, `:::::`, ``````` `````` ```````.